### PR TITLE
Remove 'Building on Polkadot' as Category option

### DIFF
--- a/data/teams.json
+++ b/data/teams.json
@@ -1,6 +1,6 @@
 {
 	"types": ["All Teams", "Substrate Builders Program", "Building for Polkadot", "Enterprise-ready"],
-  "categories": ["All", "DeFi", "Wallet", "Identity", "Social", "Smart Contracts", "File Storage", "IoT", "Gaming", "Bridge", "Infrastructure", "Relay Chain", "Connecting to Polkadot"],
+  "categories": ["All", "DeFi", "Wallet", "Identity", "Social", "Smart Contracts", "File Storage", "IoT", "Gaming", "Bridge", "Infrastructure", "Relay Chain"],
   "teams": [
     {
       "name": "Acala Network",


### PR DESCRIPTION
Removing 'Building on Polkadot' as a category option.