### PR TITLE
Update seminar page

### DIFF
--- a/data/seminars.json
+++ b/data/seminars.json
@@ -1,11 +1,19 @@
 [
   {
-    "date": "[WIP] July",
-    "description": "TBD"
+    "date": "19 Oct",
+    "description": "The Substrate new documentation hub is here and Parity’s Sacha Lansky and Lead Web Developer Imad Arain are super excited to present it to you. In this seminar, join us to learn about the improved UX features implemented to make Substrate docs easier to navigate and learn with. Learn how to navigate existing content efficiently and how to contribute new content following our contribution guidelines. Join and bring your questions to participate."
   },
   {
-    "date": "[WIP] July",
-    "description": "TBD"
+    "date": "2 Nov",
+    "description": "In this seminar, Parity Developer Advocate Sacha Lansky will walk through some of Substrate’s key concepts by diving into some intermediate level how-to guides. In doing so, he plans to showcase different implementations of certain concepts and their APIs, with a focus on how to write pallets that are customized for a particular use case. Topics will include: pallet coupling, origins and runtime configurations."
+  },
+  {
+    "date": "16 Nov",
+    "description": "Alain a.k.a Brenzi, co-founder at Integritee will dive into ways to leverage off-chain capabilities as second-layer solutions for Substrate based chains. Topics will include off-chain workers and the benefits of sidechain architectures."
+  },
+  {
+    "date": "30 Nov",
+    "description": "Michal Swietek, Co-founder of Aleph will be presenting Aleph: the first asynchronous Byzantine Fault Tolerant consensus protocol that achieves asymptotically optimal performance: constant latency and communication complexity. The goal of this talk is to give a bird’s eye view of Aleph, it’s implementation in Rust and our experience in integrating it as a finality gadget in Substrate (replacing GRANDPA with Aleph). The differences between Aleph and GRANDPA will be discussed, including performance benchmarks and some tradeoffs."
   }
 ]
 


### PR DESCRIPTION
Updated schedule for seminar. 

**Note:** Not sure where to push this to but assumed content updates was the right one. I also wasn't able to successfully run this locally because Gatsby kept throwing an error: `Cannot query field "docsUrl" on type "SiteSiteMetadata".`

Full error log:

```bash
 ERROR #85923  GRAPHQL

There was an error in your GraphQL query:

Cannot query field "siteUrl" on type "SiteSiteMetadata".

If you don't expect "siteUrl" to exist on the type "SiteSiteMetadata" it is most likely a typo.
However, if you expect "siteUrl" to exist there are a couple of solutions to common problems:

- If you added a new data source and/or changed something inside gatsby-node.js/gatsby-config.js, please try a
restart of your development server
- The field might be accessible in another subfield, please try your query in GraphiQL and use the GraphiQL
explorer to see which fields you can query and what shape they have
- You want to optionally use your field "siteUrl" and right now it is not used anywhere. Therefore Gatsby can't
infer the type and add it to the GraphQL schema. A quick fix is to add at least one entry with that field
("dummy content")

It is recommended to explicitly type your GraphQL schema if you want to use optional fields. This way you don't
have to add the mentioned "dummy content". Visit our docs to learn how you can define the schema for
"SiteSiteMetadata":
https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization#creating-type-definitions

File: src/hooks/use-site-metadata.js:15:13
```