### PR TITLE
Add relevant link to Substrate Connect page

### DIFF
--- a/src/pages/substrate-connect.js
+++ b/src/pages/substrate-connect.js
@@ -117,7 +117,10 @@ export default function Connect() {
             <PrimaryButtonLink link="https://github.com/paritytech/substrate-connect/tree/master/projects/extension">
               Get the extension
             </PrimaryButtonLink>
-            <LineArrowButton link="https://docs.substrate.io/v3/integration/substrate-connect" className="block mt-8">
+            <LineArrowButton
+              link={`${siteMetadata.docsUrl}/v${siteMetadata.docsVersion}/integration/substrate-connect/`}
+              className="block mt-8"
+            >
               Developer Docs
             </LineArrowButton>
           </div>


### PR DESCRIPTION
Not sure whether there was a reason to make it link to the general docs but this link seems more appropriate to me. I realize I don't really know the set up you're using with `siteMetadata` so apologies in advance! 😅 