### PR TITLE
Correct link underline color in banner

### DIFF
--- a/src/styles/tailwind-custom.css
+++ b/src/styles/tailwind-custom.css
@@ -219,6 +219,10 @@ div[aria-label='animation'] {
   @apply text-substrateDarkThemeBlue dark:text-substrateBlue;
 }
 
+.banner a::after {
+  @apply bg-substrateDarkThemeBlue dark:bg-substrateBlue;
+}
+
 /* Hubspot Confirmation Checkmark Animation */
 
 .checkmark__circle {


### PR DESCRIPTION
Since the banner has inverted background colors from the site's general color modes, if there are any links in the banner text the link underline appears in the wrong/opposite colors. This is the fix for that.