### PR TITLE
Adjust spacing around BlueTag

### DIFF
--- a/src/components/ui/BlueTag.js
+++ b/src/components/ui/BlueTag.js
@@ -5,7 +5,7 @@ export default function BlueTag({ title }) {
   return (
     <button
       className={cx(
-        'inline-block text-xs mr-4 px-3 py-2 rounded cursor-text',
+        'inline-block text-xs mr-2 sm:mr-4 mb-2 px-3 py-2 rounded cursor-text',
         'bg-substrateBlue bg-opacity-5 dark:bg-substrateDark',
         'border border-substrateBlue  border-opacity-20 dark:border-substrateWhite'
       )}


### PR DESCRIPTION
Addresses an issue where the BlueTag component, seen at the top of the 'Accelerators & Incubators' page, didn't have vertical spacing on flex wrap. Visible on very narrow screens like an iPhone mini. 