### PR TITLE
Update cargo contract link

### DIFF
--- a/src/components/layout/contracts/ExploreCommunityProjects.js
+++ b/src/components/layout/contracts/ExploreCommunityProjects.js
@@ -28,7 +28,7 @@ export default function ExploreCommunityProjects() {
       items: [
         {
           name: 'cargo-contract',
-          link: 'https://crates.io/crates/cargo-contract/0.8.0',
+          link: 'https://crates.io/crates/cargo-contract/',
           description: 'CLI tool to setup and deploy ink! smart contracts.',
         },
         {


### PR DESCRIPTION
We're currently linking to an old version of cargo-contract on the Smart Contracts site. Updated link to just show latest stable version.